### PR TITLE
Update corporate docs-generator lock to latest docs commit

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a970a3520b0e2c5814d763d3b41f0dca1e31750484e88fd37d4fcba815b27442
+oid sha256:219d15cbf7739280730c0447622dd70c6a57aacc4b9b54cec210b93c61e8d197
 size 122300


### PR DESCRIPTION
Point corporate to the latest docs repository commit so the build uses the new title page and wrapper fix.